### PR TITLE
Add SNPE status to admin Users table

### DIFF
--- a/simple-new-post-emails.php
+++ b/simple-new-post-emails.php
@@ -39,6 +39,8 @@ class Simple_New_Post_Emails {
 		add_action( 'personal_options_update', array( $this, 'option_save' ) );
 		add_action( 'wp_ajax_snpe-options-save', array( $this, 'ajax_option_save' ) );
 		add_action( 'publish_post', array( $this, 'publish_post' ), 10, 2 );
+		add_filter( 'manage_users_columns', array( $this, 'add_snpe_user_column') );
+		add_action( 'manage_users_custom_column', array( $this, 'show_snpe_user_column_content'), 10, 3 );
 	}
 
 	/**
@@ -157,6 +159,33 @@ class Simple_New_Post_Emails {
 		$to = apply_filters( 'snpe_to_email', '', $post );
 
 		return wp_mail( $to, $subject, $message, $headers );
+	}
+
+	/**
+	 * Add a column to the Users admin table indicating subscription status
+	 * @param array $columns    User table columns
+	 *
+	 * @return array
+	 */
+	public function add_snpe_user_column( $columns ) {
+		$columns['snpe_send'] = 'Email New Posts?';
+		return $columns;
+	}
+
+	/**
+	 * Return a user-friendly string based on the value of the user meta field
+	 * @param string $value Passed column value
+	 * @param string    $column_name    Passed column name
+	 * @param int   $user_id    User ID
+	 *
+	 * @return string
+	 */
+	public function show_snpe_user_column_content( $value, $column_name, $user_id ) {
+		$snpe_send = get_user_meta( $user_id, 'snpe_send', true );
+		if ( 'snpe_send' == $column_name ) {
+			return ( true == $snpe_send ) ? 'Yes' : 'No';
+		}
+		return $value;
 	}
 }
 

--- a/simple-new-post-emails.php
+++ b/simple-new-post-emails.php
@@ -81,9 +81,9 @@ class Simple_New_Post_Emails {
 		}
 
 		if ( isset( $_POST['snpe_send'] ) && 'Y' === $_POST['snpe_send'] ) {
-			return update_usermeta( $user_id, 'snpe_send', 'Y' );
+			return update_user_meta( $user_id, 'snpe_send', 'Y' );
 		} else {
-			return delete_usermeta( $user_id, 'snpe_send' );
+			return delete_user_meta( $user_id, 'snpe_send' );
 		}
 	}
 


### PR DESCRIPTION
Add SNPE status to admin Users table so admins can see at a glance who is subscribed to get new post notifications. Update some deprecated function calls while we're at it.
