### PR TITLE
Bump to 0.7 after 5.0 testing and mail delivery fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Simple New Post Emails #
 Contributors: 10up, helen, chrishardie  
 Requires at least: 3.0  
-Tested up to: 4.9
+Tested up to: 5.0
 License: GPLv2 or later  
 License URI: http://www.gnu.org/licenses/gpl-2.0.html  
 Stable tag: trunk  
@@ -32,6 +32,10 @@ The premise of this plugin is to keep things as simple as possible, particularly
 2. Widget in Twenty Eleven
 
 ## Changelog ##
+
+### 0.7 ###
+
+* Fix: mail delivery was failing silently in default configuration
 
 ### 0.6 ###
 * Add a column to the users admin list (props @chrishardie)

--- a/simple-new-post-emails.php
+++ b/simple-new-post-emails.php
@@ -4,7 +4,7 @@
  Plugin URI: https://github.com/10up/simple-new-post-emails
  Description: Allow site members to check a box and get new posts via email. Includes a widget.
  Author: 10up
- Version: 0.6
+ Version: 0.7
  Author URI: http://10up.com
  */
 


### PR DESCRIPTION
For 5.0 testing, I:

* Used the WordPress beta tester plugin to run 5.0-beta3-43876.
* Confirmed that as an Admin I can successfully add the widget to a sidebar.
* Confirmed that as a user I can successfully toggle my subscription status on the front-end widget.
* Confirmed that as a user I can successfully toggle my subscription status on the user profile page.
* Confirmed that the publishing of a new post generates email to a subscribed user.
* Observed no PHP warnings or errors.
