### PR TITLE
Update to reflect successful 5.4 testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Allow site members to check a box and get new posts via email. Includes a widget.
 
-[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/tag/10up/simple-new-post-emails.svg?label=release)](https://github.com/10up/simple-new-post-emails/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.3%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/simple-new-post-emails.svg)](https://github.com/10up/simple-new-post-emails/blob/develop/LICENSE.md)
+[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/tag/10up/simple-new-post-emails.svg?label=release)](https://github.com/10up/simple-new-post-emails/releases/latest) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/simple-new-post-emails) [![GPLv2 License](https://img.shields.io/github/license/10up/simple-new-post-emails.svg)](https://github.com/10up/simple-new-post-emails/blob/develop/LICENSE.md)
 
 ## Description
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Simple New Post Emails ===
-Contributors: 10up, helen, chrishardie  
-Requires at least: 3.0  
-Tested up to: 5.3
-License: GPLv2 or later  
-License URI: http://www.gnu.org/licenses/gpl-2.0.html  
-Stable tag: trunk  
+Contributors: 10up, helen, chrishardie
+Requires at least: 3.0
+Tested up to: 5.4
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Stable tag: trunk
 
 Allow site members to check a box and get new posts via email. Includes a widget.
 


### PR DESCRIPTION
For 5.4 testing, I:

* Used the WordPress beta tester plugin to run 5.4-RC3-47477.
* Confirmed that as an Admin I can successfully add the widget to a sidebar.
* Confirmed that as a user I can successfully toggle my subscription status on the front-end widget.
* Confirmed that as a user I can successfully toggle my subscription status on the user profile page.
* Confirmed that the publishing of a new post generates email to a subscribed user.
* Observed no PHP warnings or errors.