### PR TITLE
Add/GitHub actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Directories
+/.git export-ignore
+/.github export-ignore
+
+# Files
+/.gitattributes export-ignore
+/CHANGELOG.md export-ignore
+/LICENSE export-ignore
+/README.md export-ignore

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -1,0 +1,16 @@
+name: Plugin asset/readme update
+on:
+  push:
+    branches:
+    - master
+jobs:
+  master:
+    name: Push to master
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress.org plugin asset/readme update
+      uses: 10up/action-wordpress-plugin-asset-update@master
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -14,3 +14,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        ASSETS_DIR: assets

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -1,0 +1,16 @@
+name: Deploy to WordPress.org
+on:
+  push:
+    tags:
+    - "*"
+jobs:
+  tag:
+    name: New tag
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress Plugin Deploy
+      uses: 10up/action-wordpress-plugin-deploy@master
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -14,3 +14,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        ASSETS_DIR: assets


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR adds the WordPress.org plugin deploy and WordPress.org asset/readme deploy GitHub Actions to help automate the release process and updating readme/assets on WordPress.org (useful for WordPress tested-up-to version bumps).

### Alternate Designs

Keep as-is utilizing existing release/update processes.

### Benefits

Eliminates human error during release process (assuming the actions are configured correctly).

### Possible Drawbacks

Given this repo defaults to `master` instead of `develop` with releases merging from `develop` to `master`, then we'll see some of these actions firing more regularly as there will be more merges to `master` than are intended to trigger actions.  An alternate scenario would be to create a `develop` branch, set that to default, and only merge to `master` when releasing a new plugin version (or bumping WordPress tested-up-to version).

### Verification Process

Manually verified via the GitHub Desktop UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Inherits from #17.

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
```
### Added
- GitHub Actions for WordPress.org plugin and readme/asset deploys (props @jeffpaul)
```