### PR TITLE
Reflect testing against 5.5-RC3-48781

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Simple New Post Emails ===
 Contributors: 10up, helen, chrishardie
 Requires at least: 3.0
-Tested up to: 5.4
+Tested up to: 5.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Stable tag: trunk


### PR DESCRIPTION
For 5.5 testing, I:

* Used the WordPress beta tester plugin to run 5.5-RC3-48781.
* Confirmed that as an Admin I can successfully add the widget to a sidebar.
* Confirmed that as a user I can successfully toggle my subscription status on the front-end widget.
* Confirmed that as a user I can successfully toggle my subscription status on the user profile page.
* Confirmed that the publishing of a new post generates email to a subscribed user.
* Observed no PHP warnings or errors.