### PR TITLE
Update GH action to reflect new assets dir location

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -14,4 +14,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        ASSETS_DIR: assets
+        ASSETS_DIR: .wordpress-org

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -14,4 +14,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        ASSETS_DIR: assets
+        ASSETS_DIR: .wordpress-org


### PR DESCRIPTION
Per some out-of-GitHub wrangling of the repo structure, the WordPress.org assets are now stored in `.wordpress-org` instead of `assets`. This updates the GitHub deploy actions to reflect that. I hope.